### PR TITLE
Fix test_engine tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.6.1.9006
+
+* Fixed a negative test for `test_engine`.
+* Removed a memoization which keyed off a reference class object (and thus
+  never actually memoized a value).
+
 # Version 0.6.1.9001-5
 
 * `test_engine` errors if there are any test failures.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: syberia
 Type: Package
 Title: Syberia
-Version: 0.6.1.9005
+Version: 0.6.1.9006
 Description: Syberia is a meta-framework for R that allows for on-the-fly
     creation of concrete frameworks for constructing arbitrary software.
     In its current formulation, the modeling engine provides an opiniated

--- a/R/test.R
+++ b/R/test.R
@@ -336,12 +336,10 @@ find_tests <- function(engine, base, ignored_tests) {
   )
 }
 
-## We don't expect this to change after the project is loaded, so we can memoise
-## the results (store them internally so we don't have to recompute).
 ## By default, we will fetch the test configuration from
 ## `config/environments/test`, but the location of the configuration file
 ## itself is configurable (see the `config` parameter to `test_engine`).
-test_environment_configuration <- memoise::memoise(
+test_environment_configuration <- 
   function(engine, path = file.path("config", "environments", "test")) {
     if (!engine$exists(path, children. = FALSE)) {
       list()
@@ -349,7 +347,6 @@ test_environment_configuration <- memoise::memoise(
       engine$resource(path, children. = FALSE)
     }
   }
-)
 
 ## If the configuration file, usually `config/environments/test.R`,
 ## has a local variable `ignored_tests`, the tests of the 

--- a/R/test.R
+++ b/R/test.R
@@ -153,7 +153,7 @@ test_engine <- function(engine = syberia_engine(), base = "test",
 
   results <- test_resources(engine, tests$active, config, reporter = reporter)
 
-  if (error_on_failure) {
+  if (isTRUE(error_on_failure)) {
     if (!all(vapply(results, getFromNamespace("all_passed", "testthat"), logical(1)))) {
       stop("Test failures", call. = FALSE)
     }

--- a/tests/testthat/projects/test_calculation_pi/test/calculations/pi.R
+++ b/tests/testthat/projects/test_calculation_pi/test/calculations/pi.R
@@ -1,5 +1,5 @@
 test_that("the calculation is close to pi", {
   # Note we have access to the testthat package.
-  expect_less_than(abs(resource() - 3.1415926), 1e-3)
+  expect_lt(abs(resource() - 3.1415926), 1e-3)
 })
 

--- a/tests/testthat/test-engine_tests.R
+++ b/tests/testthat/test-engine_tests.R
@@ -33,7 +33,9 @@ describe("failing tests", {
   has_failed_test <- function(test_summary) {
     any(vapply(test_summary, function(summand) {
       any(vapply(summand[[1L]]$results, function(result) {
-        identical(result$passed, FALSE)
+        # The former condition is backwards-compatible with older versions of testthat
+        identical(result$passed, FALSE) ||
+        is(result, "expectation_failure")
       }, logical(1)))
     }, logical(1)))
   }

--- a/tests/testthat/test-engine_tests.R
+++ b/tests/testthat/test-engine_tests.R
@@ -41,7 +41,8 @@ describe("failing tests", {
   test_that("it fails with a simple example test", {
     # TODO: (RK) Prevent test suite reporter mangling.
     sink(tempfile()); on.exit(sink())
-    expect_true(has_failed_test(test_engine("projects/simple_test_failure")))
+    expect_true(has_failed_test(test_engine("projects/simple_test_failure",
+                                            error_on_failure = FALSE)))
   })
 })
 


### PR DESCRIPTION
* Fixed a negative test for `test_engine`.
* Removed a memoization which keyed off a reference class object (and thus
  never actually memoized a value).